### PR TITLE
Interactions with system parameters

### DIFF
--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -11,14 +11,16 @@ fn main() {
         .add_startup_system(setup)
         .add_system(update)
 
-        .add_plugin(bevy::diagnostic::LogDiagnosticsPlugin::default())
-        .add_plugin(bevy::diagnostic::EntityCountDiagnosticsPlugin::default())
+        .init_resource::<GizmosOffset>()
         
         .run();
 }
 
+#[derive(Resource, Default)]
+struct GizmosOffset(Vec3);
+
 fn setup(mut commands: Commands) {
-    println!("Trying hoering and clicking the center gizmo");
+    println!("Trying hovering and clicking the center gizmo");
 
     let cam_transform = Transform::from_xyz(0.0, 0.0, 8.0);
     commands.spawn((
@@ -30,17 +32,24 @@ fn setup(mut commands: Commands) {
     ));
 }
 
-fn update() {
+// Notice this resource is read only
+fn update(offset: Res<GizmosOffset>) {
     draw_gizmo(
-        Gizmo::new(Vec3::ZERO, 1.0, Color::WHITE)
-            .on_click(|| println!("Clicked!"))
-            .on_hover(|| println!("Hovered")),
+        Gizmo::new(Vec3::ZERO + offset.0, 1.0, Color::WHITE)
+            .on_click(|| println!("I've been clicked!"))
+            .on_hover(|| println!("Hovered"))
+            .on_hover_system(|mut offset: ResMut<GizmosOffset>, time: Res<Time>| {
+                offset.0.y -= 0.5 * time.delta_seconds();
+            })
+            .on_click_system(|mut offset: ResMut<GizmosOffset>| {
+                offset.0.y += 0.5;
+            }),
     );
 
     draw_gizmos_with_line(vec![
-        (Vec3::new(2.0, 2.0, 0.0), 0.5),
-        (Vec3::new(-2.0, 2.0, 0.0), 0.25),
-        (Vec3::new(-2.0, -2.0, 0.0), 0.75),
-        (Vec3::new(2.0, -2.0, 0.0), 1.0),
+        (Vec3::new(2.0, 2.0, 0.0) + offset.0, 0.5),
+        (Vec3::new(-2.0, 2.0, 0.0) + offset.0, 0.25),
+        (Vec3::new(-2.0, -2.0, 0.0) + offset.0, 0.75),
+        (Vec3::new(2.0, -2.0, 0.0) + offset.0, 1.0),
     ]);
 }

--- a/src/interactions.rs
+++ b/src/interactions.rs
@@ -1,20 +1,41 @@
+// Stop clippy complainging about the querys
+#![allow(clippy::type_complexity)]
+
 use crate::Gizmo;
-use bevy::prelude::*;
+use bevy::{ecs::schedule::SystemDescriptor, prelude::*};
 
 #[derive(Debug, Default)]
 pub(crate) struct GizmoInteractions {
     pub(crate) on_hover: Option<fn()>,
     pub(crate) on_click: Option<fn()>,
+    pub(crate) on_hover_system: Option<SystemDescriptor>,
+    pub(crate) on_click_system: Option<SystemDescriptor>,
 }
 
 impl Gizmo {
+    /// Run the provided function when the gizmo is hovered
     pub fn on_hover(mut self, func: fn()) -> Self {
         self.interactions.on_hover = Some(func);
         self
     }
 
+    /// Run the provided function when the gizmo is clicked on
     pub fn on_click(mut self, func: fn()) -> Self {
         self.interactions.on_click = Some(func);
+        self
+    }
+
+    /// Run the provided function when the gizmo is hovered, you can use any bevy system parameters
+    /// here but keep in mind no other systems can run at the same time as this so try to keep it short
+    pub fn on_hover_system<Params>(mut self, func: impl IntoSystemDescriptor<Params>) -> Self {
+        self.interactions.on_hover_system = Some(func.into_descriptor());
+        self
+    }
+
+    /// Run the provided function when the gizmo is clicked on, you can use any bevy system parameters
+    /// here but keep in mind no other systems can run at the same time as this so try to keep it short
+    pub fn on_click_system<Params>(mut self, func: impl IntoSystemDescriptor<Params>) -> Self {
+        self.interactions.on_click_system = Some(func.into_descriptor());
         self
     }
 }
@@ -29,8 +50,17 @@ pub struct OnHover(pub(crate) fn());
 #[derive(Component)]
 pub struct OnClick(pub(crate) fn());
 
+#[derive(Component)]
+pub struct OnHoverSystem(pub(crate) SystemDescriptor);
+
+#[derive(Component)]
+pub struct OnClickSystem(pub(crate) SystemDescriptor);
+
 pub(crate) fn interactions_handler(
-    query: Query<(Option<&OnHover>, Option<&OnClick>, &Transform)>,
+    query: Query<
+        (Option<&OnHover>, Option<&OnClick>, &Transform),
+        Or<(With<OnHover>, With<OnClick>)>,
+    >,
     camera: Query<(&Camera, &GlobalTransform), With<GizmoInteractionCamera>>,
     mouse_btns: Res<Input<MouseButton>>,
     windows: Res<Windows>,
@@ -51,28 +81,98 @@ pub(crate) fn interactions_handler(
     };
 
     for (on_hover, on_click, transform) in query.iter() {
-        // Cast a ray from the camera at the mouse position
-        if let Some(ray) = camera.viewport_to_world(cam_transform, mouse_pos) {
-            let origin = ray.origin - transform.translation;
-            let closest_point = ray.direction.dot(origin);
-            let distance = (origin - closest_point * ray.direction).length();
+        let distance = gizmo_distance(camera, cam_transform, mouse_pos, transform.translation);
+        if distance > transform.scale.x {
+            continue;
+        }
+        // On Hover
+        if let Some(on_hover) = on_hover {
+            on_hover.0();
+        }
 
-            // If the distance value if less than the gizmo
-            // size then the gizmo is behind the cursor
-            if distance < transform.scale.x {
-                // On Hover
-                if let Some(on_hover) = on_hover {
-                    on_hover.0();
-                }
+        // On Click
+        if let Some(on_click) = on_click {
+            if !mouse_btns.just_pressed(MouseButton::Left) {
+                continue;
+            }
+            on_click.0();
+        }
+    }
+}
 
-                // On Click
-                if let Some(on_click) = on_click {
-                    if !mouse_btns.just_pressed(MouseButton::Left) {
-                        continue;
-                    }
-                    on_click.0();
-                }
+pub(crate) fn interactions_handler_system(world: &mut World) {
+    let clicked = world
+        .resource::<Input<MouseButton>>()
+        .just_pressed(MouseButton::Left);
+
+    // Get the mouse position
+    let windows = world.resource::<Windows>();
+    let mouse_pos = if let Some(Some(pos)) = windows.get_primary().map(|w| w.cursor_position()) {
+        pos
+    } else {
+        // Most likely the cursor isn't within the window
+        return;
+    };
+
+    // Get the gizmo camera
+    let mut camera: QueryState<(&Camera, &GlobalTransform), With<GizmoInteractionCamera>> =
+        world.query_filtered();
+    let (camera, cam_transform) = if let Ok(cam) = camera.get_single(world) {
+        (cam.0.to_owned(), cam.1.to_owned())
+    } else {
+        return;
+    };
+
+    let mut app = App::new();
+    std::mem::swap(&mut app.world, world);
+
+    let mut query: QueryState<
+        Entity,
+        (
+            Or<(With<OnHoverSystem>, With<OnClickSystem>)>,
+            With<Transform>,
+        ),
+    > = app.world.query_filtered();
+
+    let entities: Vec<Entity> = query.iter(&app.world).collect();
+
+    for e in entities {
+        let on_hover = app.world.entity_mut(e).remove::<OnHoverSystem>();
+        let on_click = app.world.entity_mut(e).remove::<OnClickSystem>();
+        let transform = app.world.entity(e).get::<Transform>().unwrap();
+
+        let distance = gizmo_distance(&camera, &cam_transform, mouse_pos, transform.translation);
+        if distance > transform.scale.x {
+            continue;
+        }
+
+        if let Some(on_hover) = on_hover {
+            app.add_system(on_hover.0);
+        }
+
+        if clicked {
+            if let Some(on_click) = on_click {
+                app.add_system(on_click.0);
             }
         }
+    }
+
+    app.update();
+    std::mem::swap(&mut app.world, world);
+}
+
+// Calculates the distance from the cursor to the gizmo
+fn gizmo_distance(
+    cam: &Camera,
+    cam_transform: &GlobalTransform,
+    mouse_pos: Vec2,
+    gizmo_pos: Vec3,
+) -> f32 {
+    if let Some(ray) = cam.viewport_to_world(cam_transform, mouse_pos) {
+        let origin = ray.origin - gizmo_pos;
+        let closest_point = ray.direction.dot(origin);
+        (origin - closest_point * ray.direction).length()
+    } else {
+        f32::INFINITY
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,6 @@
 //! # Examples
 //!
-//! Draw a single gizmo
+//! Draw a single [`gizmo`](Gizmo)
 //! ```
 //! # use bevy::prelude::*;
 //! # use bevy_mod_gizmos::*;
@@ -39,7 +39,7 @@
 //! The rest of the methods can be found <a href="#functions">here</a>.
 
 use bevy::prelude::*;
-use interactions::interactions_handler;
+use interactions::{interactions_handler, interactions_handler_system};
 use spawning::{cleanup, spawn_gizmos};
 
 mod api;
@@ -61,5 +61,6 @@ impl Plugin for GizmosPlugin {
         app.add_system_to_stage(CoreStage::PreUpdate, cleanup);
         app.add_system_to_stage(CoreStage::PreUpdate, spawn_gizmos.after(cleanup));
         app.add_system_to_stage(CoreStage::PostUpdate, interactions_handler);
+        app.add_system_to_stage(CoreStage::PostUpdate, interactions_handler_system);
     }
 }

--- a/src/spawning.rs
+++ b/src/spawning.rs
@@ -1,5 +1,5 @@
 use crate::{
-    interactions::{OnClick, OnHover},
+    interactions::{OnClick, OnClickSystem, OnHover, OnHoverSystem},
     line::Line,
     Gizmo,
 };
@@ -55,6 +55,14 @@ pub(crate) fn spawn_gizmos(
 
             if let Some(func) = gizmo.interactions.on_click {
                 e.insert(OnClick(func));
+            }
+
+            if let Some(func) = gizmo.interactions.on_hover_system {
+                e.insert(OnHoverSystem(func));
+            }
+
+            if let Some(func) = gizmo.interactions.on_click_system {
+                e.insert(OnClickSystem(func));
             }
         }
     }


### PR DESCRIPTION
Ability to access bevy system parameters with interactive gizmos.

### Features

- `Gizmo.on_hover_system()`
- `Gizmo.on_click_system()`

These methods can take any valid bevy system and execute them.

### Usage

Usage is shown in the [demo example](https://github.com/LiamGallagher737/bevy_mod_gizmos/blob/interactions-with-system-parameters/examples/demo.rs) lines 41 to 46.

```rs
.on_hover_system(|mut offset: ResMut<GizmosOffset>, time: Res<Time>| {
    offset.0.y -= 0.5 * time.delta_seconds();
})
.on_click_system(|mut offset: ResMut<GizmosOffset>| {
    offset.0.y += 0.5;
})
```